### PR TITLE
Fix reaction exploit

### DIFF
--- a/ned_bot.py
+++ b/ned_bot.py
@@ -38,17 +38,11 @@ async def on_raw_reaction_add(payload):
         channel = NED_BOT.get_channel(payload.channel_id)
         # Gets the message that the reaction was made in
         message = await channel.fetch_message(payload.message_id)
-        # Iterates through the reactions of the message
-        for reaction in range(0, len(message.reactions)):
-            # If the reaction of the emoji "N" was made
-            if message.reactions[reaction].emoji == '🇳':
-                # Makes sure we don't get an off by 1 error
-                if reaction + 1 <= len(message.reactions):
-                    # If the next emoji is an "E"
-                    if message.reactions[reaction + 1].emoji == '🇪':
-                        # Complete the bot's name
-                        await message.add_reaction('🇩')
-                        logging.error('Spelled my name :)')
+        for reaction in message.reactions:
+            if reaction.emoji == '🇳':
+                await message.add_reaction('🇩')
+                logging.error('Spelled my name :)')
+                break
 # Swear word checker
 @NED_BOT.event
 async def on_message(message):


### PR DESCRIPTION
- Users previously could react with a 'n' and then any emoji and then an
  'e' and a 'r', 'd' and then unreact the placeholder emoji
- Fixed by reacting with a 'd' whenever there is a 'n' before an 'e'